### PR TITLE
Added __len__ and fixed __getitem__

### DIFF
--- a/src/confpool.cpp
+++ b/src/confpool.cpp
@@ -341,9 +341,12 @@ py::dict Confpool::rmsd_filter(const py::float_& py_rmsd_cutoff) {
 }
 
 py::object Confpool::__getitem__(const py::object& key) {
-    if (py::isinstance<py::int_>(key))
-        return py::cast(proxies_[key.cast<int>()]);
-    else if (py::isinstance<py::str>(key))
+    if (py::isinstance<py::int_>(key)) {
+        if (key.cast<int>() < coord_.size())
+            return py::cast(proxies_[key.cast<int>()]);
+        else
+            throw py::index_error("Confpool index out of range");
+    }else if (py::isinstance<py::str>(key))
         return key_to_list(key.cast<std::string>());
     else
         throw std::runtime_error(fmt::format("Expected either an integer (conformer index) or a string (a key). Got a {}", py::repr(key).cast<std::string>()));

--- a/src/confpool.cpp
+++ b/src/confpool.cpp
@@ -380,6 +380,10 @@ py::object Confpool::__getattr__(const py::str& py_attr) {
         throw std::runtime_error(fmt::format("Unknown attr {}", attr));
 }
 
+py::object Confpool::__len__() {
+    return py::cast(coord_.size());
+}
+
 void Confpool::__setattr__(const py::str& py_attr, const py::object& value) {
     const auto attr = py_attr.cast<std::string>();
     if (attr == "descr") {

--- a/src/confpool.cpp
+++ b/src/confpool.cpp
@@ -380,7 +380,7 @@ py::object Confpool::__getattr__(const py::str& py_attr) {
         throw std::runtime_error(fmt::format("Unknown attr {}", attr));
 }
 
-py::object Confpool::__len__() {
+py::int_ Confpool::__len__() {
     return py::cast(coord_.size());
 }
 

--- a/src/confpool.h
+++ b/src/confpool.h
@@ -44,6 +44,8 @@ class Confpool {
         void __setattr__(const py::str& py_attr, const py::object& func);
         void __delitem__(const py::object& py_key);
 
+        py::int_ __len__(); 
+
         py::int_ include_from_file(const py::str& py_filename);
         void include_from_xyz(const py::array_t<double>& xyz, const py::str& descr);
         void include_subset(Confpool& other, const py::list& py_idxs);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -23,6 +23,7 @@ PYBIND11_MODULE(confpool, m) {
         .def("__getattr__", &Confpool::__getattr__)
         .def("__setattr__", &Confpool::__setattr__)
         .def("__delitem__", &Confpool::__delitem__)
+        .def("__len__", &Confpool::__len__)
         .def("include_from_file", &Confpool::include_from_file)
         .def("include_from_xyz", &Confpool::include_from_xyz)
         .def("include_subset", &Confpool::include_subset)


### PR DESCRIPTION
I've defined __len__ method, that provides us abillity to get the lengh of Confpool in a pythonish way: len(pool). Also I've modified __getitem__ method by throwing a IndexError when index bigger then size of Confpool. This change allows us iterates through Confpool without defining __next__ and __iter__ methods.